### PR TITLE
Missing ! on isCommittee check

### DIFF
--- a/commands/upCommand.go
+++ b/commands/upCommand.go
@@ -25,7 +25,7 @@ type statusCheck struct {
 // Up command to check the status of various websites hosted on Netsoc servers
 func checkUpCommand(ctx context.Context, s *discordgo.Session, m *discordgo.MessageCreate) {
 	// Check if committee channel, don't allow in public server
-	if isCommittee(m) {
+	if !isCommittee(m) {
 		return
 	}
 


### PR DESCRIPTION
Missing logical not meaning the command would run on non-committee servers and not on the committee server